### PR TITLE
Add troubleshooting for Windows on NVMe SSD

### DIFF
--- a/docs/troubleshooting/boot.md
+++ b/docs/troubleshooting/boot.md
@@ -693,6 +693,15 @@ Certain BIOS settings can cause boot problems:
 - Check mounting standoffs not shorting traces
 - Look for bent capacitors touching heatsink
 
+#### 5. Windows installed on NVMe SSD
+Having a Windows installation on the SSD has been known to prevent boot altogether. To resolve:
+- Remove the SSD from the BC250
+- Use an SSD to USB adapter to connect the drive externally on the BC250
+- Use a Linux installation on a USB stick to boot the BC250
+- Use a partition management tool to delete all partitions from the SSD
+- Create a single large partition of type Ext4
+- Reinstall the SSD onto the BC250
+
 ---
 
 ## Diagnostic Commands


### PR DESCRIPTION
Added troubleshooting steps for Windows on NVMe SSD.
Before I tried booting my BC250 for the first time, I had installed an SSD fresh out of a Windows laptop.  I could not get any response from the BC250 whatsoever.  Of course, I followed all of the troubleshooting directions, but I had no luck.  For lack of anything better to try, I removed the SSD from the BC250 and, to my surprise, the system finally booted.
After identifying the problem, it was fairly easy to work out how to remove the windows partitions from the SSD.  I already had an adaptor to mount the SSD over USB.
I don't know the mechanism how the windows installation completely prevents boot.  I just know that it can.