### PR TITLE
Consistent Micro-Stutters Solution

### DIFF
--- a/docs/linux/bazzite.md
+++ b/docs/linux/bazzite.md
@@ -302,6 +302,21 @@ systemctl reboot
    - Confirm it worked by verifying that the time/clock in the BIOS was reset and shows the wrong value
 - Reapply the BIOS settings changes, such as the VRAM allocation
 
+### Consistent Micro-stuttering during Gameplay
+
+**Symptom:** Consistent micro-stutters every couple of seconds even for the least demanding 2D games.
+
+**Cause:** The built-in Bazzite Handheld Daemon fails to load required functionality (not present on BC-250), and inevitably fails and restarts continually.
+
+**Solution:** Disable the Handheld Daemon (HHD).
+
+```bash
+sudo systemctl disable --now hhd
+
+# Prevent from being re-enabled in future update
+sudo systemctl mask hhd
+```
+
 ### Governor Voltage Instability
 
 **Symptom:** Graphics artifacts, crashes, black screens


### PR DESCRIPTION
In my testing while using Bazzite, I always had consistent micro-stutters (every couple of seconds) while playing the least demanding of 2D games.

Disabling the governor had no impact, stuttering continued. Later in my testing, I identified Bazzite's Handheld Daemon as the root cause of this stuttering. The journalctl revealed that the process kept failing and restarting. Disabling it fixed the micro-stuttering completely. This proposed solution informs users to disable this software to fix the micro-stutters.