### PR TITLE
docs: address issues #21, #22, #23

### DIFF
--- a/docs/bios/flashing.md
+++ b/docs/bios/flashing.md
@@ -1,6 +1,9 @@
 # BIOS Flashing Guide
 
-Flashing the modded BIOS is essential for unlocking the BC-250's full potential. It primarily enables **dynamic VRAM allocation** and grants access to **advanced chipset settings** that are hidden in the stock configuration.
+Flashing the modded BIOS is the recommended way to unlock the BC-250's full potential. It primarily enables **dynamic VRAM allocation** and grants access to **advanced chipset settings** that are hidden in the stock configuration.
+
+!!!tip "Not always required"
+    If your only goal is changing VRAM size, you can do that from Linux on the stock P3.00 / P5.00 BIOS using [bc250_memcfg](https://github.com/fanoush/bc250_memcfg). See [VRAM Configuration](vram.md#changing-vram-allocation) for details. Flashing is only needed if you want the unlocked chipset menus or features beyond VRAM sizing.
 
 !!!danger "Hardware Safety: GPU Power Connector"
     Ensure the 8-pin PCIe power connector is wired correctly BEFORE attempting to flash.

--- a/docs/bios/vram.md
+++ b/docs/bios/vram.md
@@ -122,6 +122,20 @@ CPU-favoring split.
 !!!warning "Takes Effect Immediately"
     The new allocation applies on reboot. No need to reflash BIOS or reinstall OS.
 
+### From Linux (no BIOS flash needed)
+
+If you only need to change VRAM size, you can set it from a running Linux system on the stock P3.00 or P5.00 BIOS using [fanoush/bc250_memcfg](https://github.com/fanoush/bc250_memcfg):
+
+```bash
+git clone https://github.com/fanoush/bc250_memcfg
+cd bc250_memcfg
+make
+sudo ./bc250memcfg UMA_SIZE 512    # 512MB dynamic
+# values: 512, 4096, 6144, 8192
+```
+
+Reboot for the new allocation to apply. Useful if you want VRAM sizing without flashing a modded BIOS.
+
 ### Verification in Linux
 
 Check current allocation:

--- a/docs/linux/debian.md
+++ b/docs/linux/debian.md
@@ -27,9 +27,6 @@ Debian and PikaOS offer stable, low-power options for the BC-250. While requirin
 - More manual configuration needed
 - Kernel selection critical
 
-!!!info "Pre-built Debian Image Available"
-    A pre-built Debian image exists with kernel 6.18.3, Mesa 26, and GPU patches pre-applied. This significantly reduces setup complexity for new users. Check community resources for access.
-
 ### PikaOS
 
 **Advantages:**

--- a/docs/linux/kernel.md
+++ b/docs/linux/kernel.md
@@ -365,6 +365,36 @@ Required for:
 
 **Alternative:** Use distributions with patch pre-applied (Bazzite, PikaOS) or use the SMU governor
 
+### 40 CU Unlock Patch (Experimental)
+
+**Purpose:** Re-enables all 40 RDNA2 CUs on the BC-250 (stock ships with 24 of 40 active).
+
+**Status:** Experimental. Submitted as [CachyOS/kernel-patches#159](https://github.com/CachyOS/kernel-patches/pull/159) by duggasco. Not yet merged upstream.
+
+**How it works:** Writes two hardware registers during `gfx_v10_0_get_cu_info()`:
+
+- `CC_GC_SHADER_ARRAY_CONFIG` — clears the harvest enumeration mask
+- `SPI_PG_ENABLE_STATIC_WGP_MASK` — enables SPI wave dispatch to all 5 WGPs per shader array
+
+Both registers must be written together — neither alone produces compute scaling.
+
+**Safety:**
+
+- Default off, opt-in via `amdgpu.bc250_cc_write_mode=3` kernel parameter
+- Guarded by PCI device ID `0x13FE` (BC-250 only)
+- No permanent hardware change — rebooting without the parameter returns to stock
+
+**Reported results** (Vulkan llama-bench pp512, same board):
+
+| State                              | pp512 tok/s | Power |
+|------------------------------------|-------------|-------|
+| Stock (24 CU)                      | 302         | 56 W  |
+| **Both registers (40 CU)**         | **466**     | **181 W** |
+
+At 1500 MHz / 900 mV: 230 → 372 tok/s (1.61x). Power draw goes up significantly — only worth it for compute-heavy workloads.
+
+**Reference:** Full writeup at [duggasco/bc250-40cu-unlock](https://github.com/duggasco/bc250-40cu-unlock).
+
 ### TKG Kernel (Arch-based)
 
 For Arch users, linux-tkg provides easy custom kernel building:


### PR DESCRIPTION
Closes #21, closes #22, closes #23.

## #21 — modded BIOS overstated as "essential"
- `docs/bios/flashing.md`: changed "essential" to "recommended", added a tip box pointing at `fanoush/bc250_memcfg` for the VRAM-only use case.
- `docs/bios/vram.md`: added a "From Linux" section under "Changing VRAM Allocation" documenting `bc250_memcfg` as an alternative to flashing.

## #22 — missing prebuilt Debian image link
- `docs/linux/debian.md`: removed the unsourced `!!!info` block. If the image actually lives somewhere we can link, put it back with the link.

## #23 — 40 CU unlock patch
- `docs/linux/kernel.md`: added an "40 CU Unlock Patch (Experimental)" subsection under "Kernel Patches for BC-250" covering the CachyOS PR #159 by duggasco, the two registers involved, the safety guarantees, and the reported llama-bench numbers.

## Test plan
- [ ] `mkdocs serve` renders cleanly, no broken anchors
- [ ] vram.md `#changing-vram-allocation` anchor from flashing.md still resolves
- [ ] Wording on flashing.md still discourages random P5.00_clv flashes