### PR TITLE
site: add GitHub star and Discussions CTA

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -104,9 +104,45 @@ This documentation is built from the collective knowledge of the BC250 community
 - **Active Discord community** sharing real-world testing and troubleshooting
 - **Multiple distribution-specific setup guides**
 
-### Contributing
+### Get Involved
 
-This documentation is based on community Discord discussions and the [BC250 GitHub repository](https://github.com/mothenjoyer69/bc250-documentation). If you find errors or have improvements, please contribute!
+This is a community project and it gets better every time someone shows up with a fix, a benchmark, a build photo or a question that pushes a section to be clearer. A few low-effort things that help a lot:
+
+<div class="grid cards" markdown>
+
+-   :material-star:{ .lg .middle } __Star the repo__
+
+    ---
+
+    If this saved you a few hours of digging through Discord, a star helps other people find it too.
+
+    [:octicons-arrow-right-24: GitHub](https://github.com/elektricM/amd-bc250-docs)
+
+-   :material-forum:{ .lg .middle } __Join the Discussions__
+
+    ---
+
+    Got a working cooling setup, a benchmark, a weird issue, or a question that doesn't quite fit an issue? Drop it in Discussions. It is much easier to find later than Discord scrollback.
+
+    [:octicons-arrow-right-24: Discussions](https://github.com/elektricM/amd-bc250-docs/discussions)
+
+-   :material-source-pull:{ .lg .middle } __Open a PR__
+
+    ---
+
+    Found a typo, a broken command, a missing distro guide, or a hardware quirk that should be documented? PRs welcome, even tiny ones.
+
+    [:octicons-arrow-right-24: Contribute](https://github.com/elektricM/amd-bc250-docs/pulls)
+
+-   :material-bug:{ .lg .middle } __Report an issue__
+
+    ---
+
+    Something in the docs is wrong, outdated, or actively misleading? File an issue and it gets fixed.
+
+    [:octicons-arrow-right-24: Issues](https://github.com/elektricM/amd-bc250-docs/issues)
+
+</div>
 
 ## Documentation Status
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ edit_uri: edit/main/docs/
 # Theme
 theme:
   name: material
+  custom_dir: overrides
   palette:
     # Palette toggle for automatic light/dark mode
     - media: "(prefers-color-scheme)"
@@ -53,6 +54,7 @@ theme:
     - content.tabs.link
     - content.action.edit
     - content.action.view
+    - announce.dismiss
 
   icon:
     repo: fontawesome/brands/github

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block announce %}
+  Found this useful?
+  <a href="https://github.com/elektricM/amd-bc250-docs" target="_blank" rel="noopener">
+    Star the project on GitHub
+  </a>
+  and join the
+  <a href="https://github.com/elektricM/amd-bc250-docs/discussions" target="_blank" rel="noopener">
+    community discussions
+  </a>
+  to share builds, ask questions, and help shape the docs.
+{% endblock %}


### PR DESCRIPTION
A lot of readers land on the docs through Google or a Discord link, read what they need, and never make it back to the GitHub side of the project. Adding two small surfaces to nudge them:

## What's in this PR

**Site-wide announce banner (`overrides/main.html` + `mkdocs.yml`)**

Adds a thin banner at the top of every page inviting readers to star the repo and join Discussions. Uses Material's built-in `announce` block, so it's dismissable once a reader has seen it (no nagging). Required two small changes in `mkdocs.yml`:

- `theme.custom_dir: overrides` to pull in the template override
- `announce.dismiss` added to `theme.features` so the close button works

**Home page Get Involved section (`docs/index.md`)**

Replaces the existing one-paragraph "Contributing" note with a 4-card grid: Star the repo, Discussions, PRs, Issues. Each card is a low-effort ask with a one-line reason why it helps. The cards live where the old Contributing paragraph was, so the visual flow of the page is preserved.

## Why this and not more

Considered going further (footer CTAs on every page, dedicated Community page, etc.) but kept it to two surfaces on purpose. The banner is global and the home section is high-traffic, and that should be enough lift without making the docs feel like a marketing site.