### PR TITLE
docs: repoint cyan-skillfish-governor links to filippor, drop stale .deb path

### DIFF
--- a/docs/linux/cachyos.md
+++ b/docs/linux/cachyos.md
@@ -167,7 +167,7 @@ systemctl status cyan-skillfish-governor-tt
 
 **Method 3: Build from source**
 
-See [github.com/Magnap/cyan-skillfish-governor](https://github.com/Magnap/cyan-skillfish-governor) for build instructions. The SMU variant is in the `smu` branch.
+See [github.com/filippor/cyan-skillfish-governor](https://github.com/filippor/cyan-skillfish-governor) for build instructions. The SMU variant lives on the `smu` branch.
 
 **Verify it's working:**
 ```bash

--- a/docs/linux/debian.md
+++ b/docs/linux/debian.md
@@ -203,14 +203,15 @@ Remove `nomodeset` if you added it during installation (after Mesa is installed)
 
 A GPU governor is required for proper GPU frequency scaling.
 
-**Option 1: Install cyan-skillfish-governor-smu from .deb (recommended)**
+**Option 1: Install cyan-skillfish-governor-smu from release tarball (recommended)**
 
-The SMU governor is available as a .deb package from [filippor's releases](https://github.com/Magnap/cyan-skillfish-governor/releases). It bypasses kernel patching entirely.
+Upstream does not ship a `.deb`. The SMU governor is distributed as a release tarball from [filippor's releases](https://github.com/filippor/cyan-skillfish-governor/releases). It bypasses kernel patching entirely.
 
 ```bash
-# Download .deb from GitHub releases
-wget https://github.com/Magnap/cyan-skillfish-governor/releases/latest/download/cyan-skillfish-governor-smu_amd64.deb
-sudo dpkg -i cyan-skillfish-governor-smu_amd64.deb
+# Grab the latest cyan-skillfish-governor-smu-*-x86_64-linux.tar.gz from the releases page, then:
+tar -xf cyan-skillfish-governor-smu-*-x86_64-linux.tar.gz
+cd cyan-skillfish-governor-smu-*/
+sudo ./scripts/install.sh
 sudo systemctl enable --now cyan-skillfish-governor-smu.service
 ```
 

--- a/docs/system/governor.md
+++ b/docs/system/governor.md
@@ -47,11 +47,11 @@ The GPU governor is essential for BC-250 performance, enabling dynamic frequency
 **Features:**
 - Multiple frequency steps with thermal throttling
 - Maintains GPU usage in optimal range
-- Available as COPR/RPM, AUR, .deb, Nix
+- Available as COPR/RPM and AUR
 - Requires kernel frequency range patch (pre-included in Bazzite)
 
 **COPR:** `filippor/bazzite`
-**Repository:** [github.com/Magnap/cyan-skillfish-governor](https://github.com/Magnap/cyan-skillfish-governor)
+**Repository:** [github.com/filippor/cyan-skillfish-governor](https://github.com/filippor/cyan-skillfish-governor)
 
 !!!warning "Service Name Changed (Dec 2025)"
     filippor renamed the service from `cyan-skillfish-governor` to `cyan-skillfish-governor-tt` on Dec 13, 2025. Config folder moved from `/etc/cyan-skillfish-governor/` to `/etc/cyan-skillfish-governor-tt/`. If upgrading, migrate your config:
@@ -71,7 +71,7 @@ The GPU governor is essential for BC-250 performance, enabling dynamic frequency
 **Features:**
 - Manages clock speeds through SMU firmware calls
 - **Does NOT require kernel frequency range patch on any distro**
-- Available on AUR (`cyan-skillfish-governor-smu`), COPR (`filippor/bazzite`), .deb, .rpm, Nix
+- Available on AUR (`cyan-skillfish-governor-smu`) and COPR (`filippor/bazzite`); release tarball for all other distros
 - Works on all distros without kernel patching
 - Community recommended default (Mar 2026+)
 
@@ -172,19 +172,21 @@ sudo systemctl enable --now cyan-skillfish-governor-tt.service
 !!!info "COPR Package Status"
     The `filippor/bazzite` COPR provides both `cyan-skillfish-governor-smu` (recommended) and `cyan-skillfish-governor-tt` (alternative). Confirmed working as of Mar 2026.
 
-### Option 2: Debian/Ubuntu (.deb)
+### Option 2: Debian/Ubuntu/Generic Linux (release tarball)
+
+Upstream does not ship a `.deb`. Use the release tarball from [filippor's releases page](https://github.com/filippor/cyan-skillfish-governor/releases):
 
 ```bash
-# Download .deb from GitHub releases
-# Check https://github.com/Magnap/cyan-skillfish-governor/releases for latest
-wget https://github.com/Magnap/cyan-skillfish-governor/releases/latest/download/cyan-skillfish-governor-smu_amd64.deb
-sudo dpkg -i cyan-skillfish-governor-smu_amd64.deb
+# Grab the latest cyan-skillfish-governor-smu-*-x86_64-linux.tar.gz, then:
+tar -xf cyan-skillfish-governor-smu-*-x86_64-linux.tar.gz
+cd cyan-skillfish-governor-smu-*/
+sudo ./scripts/install.sh
 sudo systemctl enable --now cyan-skillfish-governor-smu.service
 ```
 
-### Option 3: Other Distros / Build from Source
+### Option 3: Build from Source
 
-See [github.com/Magnap/cyan-skillfish-governor](https://github.com/Magnap/cyan-skillfish-governor) for build instructions. The SMU variant is in the `smu` branch.
+See [github.com/filippor/cyan-skillfish-governor](https://github.com/filippor/cyan-skillfish-governor) for build instructions. The SMU variant lives on the `smu` branch and builds with `cargo build --release`.
 
 ## Configuration
 

--- a/docs/troubleshooting/performance.md
+++ b/docs/troubleshooting/performance.md
@@ -65,8 +65,8 @@ dnf install cyan-skillfish-governor-smu
 yay -S cyan-skillfish-governor-smu
 ```
 
-**Debian:**
-Download `.deb` from [GitHub releases](https://github.com/Magnap/cyan-skillfish-governor/releases)
+**Debian/Ubuntu:**
+Upstream does not ship a `.deb`. Grab the latest `cyan-skillfish-governor-smu-*-x86_64-linux.tar.gz` from [filippor's releases](https://github.com/filippor/cyan-skillfish-governor/releases), extract it, and run `sudo ./scripts/install.sh`.
 
 **Configuration:**
 


### PR DESCRIPTION
## Summary

The active upstream of `cyan-skillfish-governor` is [`filippor/cyan-skillfish-governor`](https://github.com/filippor/cyan-skillfish-governor) (v0.4.6, May 2026, 27★), not [`Magnap/cyan-skillfish-governor`](https://github.com/Magnap/cyan-skillfish-governor) (v0.1.3, Aug 2025, 12★ — 9 months stale). Several install paths in the docs were pointing readers at Magnap releases and telling them to `wget` a `.deb` that no longer exists in the upstream release pipeline (filippor ships an `x86_64-linux.tar.gz` + `scripts/install.sh` only).

### Changes
- **`system/governor.md`**:
  - TT section repository link: Magnap → filippor.
  - SMU feature list: drop `.deb`/Nix claims (no longer accurate); reword to "AUR + COPR + release tarball".
  - Option 2 (Debian/Ubuntu) rewritten as tarball install via `scripts/install.sh`.
  - Option 3 (Other Distros / Build from Source) link: Magnap → filippor; mention `cargo build --release`.
- **`linux/cachyos.md`**: build-from-source link Magnap → filippor.
- **`linux/debian.md`**: Option 1 rewritten as tarball install via `scripts/install.sh`.
- **`troubleshooting/performance.md`**: Debian one-liner rewritten to point at filippor's releases.

Magnap is preserved as historical credit in two developer-attribution lines (the SMU governor originated in Magnap's repo; filippor maintains the active fork). All download/repo URLs now point at filippor.

### Verification
- Filippor's release assets confirmed via `gh api`: every release v0.3.x and v0.4.x ships only `cyan-skillfish-governor-smu-vX.Y.Z-x86_64-linux.tar.gz` + `.sha256`.
- Install path confirmed against the `smu` branch README ("Generic Linux" section).
- No regressions to existing in-docs references to filippor (smu branch URL was already in use elsewhere).

## Test plan

- [ ] Render the site locally (`mkdocs serve`) and walk through:
  - [ ] `system/governor.md` Installation section reads cleanly with the three options.
  - [ ] `linux/debian.md` Option 1 ends at a runnable command.
  - [ ] `linux/cachyos.md` build-from-source link resolves.
  - [ ] `troubleshooting/performance.md` Debian/Ubuntu line resolves.
- [ ] Click through the new filippor URLs to confirm they resolve to a real releases page / repo.