### PR TITLE
docs: reference community setup toolkits for BC-250

### DIFF
--- a/docs/linux/bazzite.md
+++ b/docs/linux/bazzite.md
@@ -11,6 +11,9 @@ Bazzite is a gaming-focused Linux distribution based on Fedora that provides an 
 
 ---
 
+!!!tip "Prefer a script?"
+    Community toolkits like [NexGen-3D-Printing/SteamMachine](https://github.com/NexGen-3D-Printing/SteamMachine), [samedayhurt/bc250-buddy](https://github.com/samedayhurt/bc250-buddy) and [NeOdYmS/bazzite-bc250-toolkit](https://github.com/NeOdYmS/bazzite-bc250-toolkit) automate the steps below; see [Community Setup Toolkits](distributions.md#community-setup-toolkits).
+
 ## Why Choose Bazzite?
 
 **Advantages:**

--- a/docs/linux/cachyos.md
+++ b/docs/linux/cachyos.md
@@ -12,6 +12,9 @@ CachyOS is an Arch-based Linux distribution optimized for performance, featuring
 !!! success "Updated November 2025"
     CachyOS now ships with compatible kernels by default. The complex custom ISO build procedures from earlier guides are **no longer needed**. Simply download the standard ISO and install normally.
 
+!!!tip "Prefer a script?"
+    [redbeard1083/bc250-toolkit](https://github.com/redbeard1083/bc250-toolkit) automates governor, swap, overclock and CU unlock on CachyOS (needs the Limine bootloader); see [Community Setup Toolkits](distributions.md#community-setup-toolkits).
+
 ---
 
 ## Why Choose CachyOS?

--- a/docs/linux/distributions.md
+++ b/docs/linux/distributions.md
@@ -13,6 +13,14 @@ Choosing the right Linux distribution for your BC-250 is important for a smooth 
 | **Stability** | Debian/PikaOS | Rock-solid, good for production work |
 | **Minimal / DIY** | Alpine Linux | Tiny OpenRC-based system for advanced manual setups |
 
+## Community Setup Toolkits
+
+Several community projects bundle the common post-install steps (governor, overclock, swap, compute-unit unlock) into one script or menu. They move fast and aren't maintained here, so read what they do before running them. The per-distro guides below stay the reference for what each step actually does.
+
+- **Bazzite:** [NexGen-3D-Printing/SteamMachine](https://github.com/NexGen-3D-Printing/SteamMachine) gives you one-shot tuning scripts plus a 3D-printed case; [samedayhurt/bc250-buddy](https://github.com/samedayhurt/bc250-buddy) is a modular setup with matching revert scripts; [NeOdYmS/bazzite-bc250-toolkit](https://github.com/NeOdYmS/bazzite-bc250-toolkit) is a menu-driven setup that includes the nct6683 to nct6687 sensor switch.
+- **CachyOS:** [redbeard1083/bc250-toolkit](https://github.com/redbeard1083/bc250-toolkit) is a menu-driven setup covering governor, swap, on-the-fly overclock and compute-unit unlock. It needs the Limine bootloader.
+- **Arch:** [pnbarbeito/bc250-arch](https://github.com/pnbarbeito/bc250-arch) installs oberon-governor and mesa-git; [Boundbygravity/bc250-arch-setup](https://github.com/Boundbygravity/bc250-arch-setup) is a post-install setup script.
+
 ## Fedora 43 (Most Recommended for Beginners)
 
 !!!warning "Fedora 42 is End of Life"


### PR DESCRIPTION
## What's in this PR

A consolidated **Community Setup Toolkits** section in `linux/distributions.md` (between Quick Recommendations and the Fedora section), plus a one-line `!!!tip` pointer at the top of `bazzite.md` and `cachyos.md`.

The community has settled on script and menu-driven setup projects that bundle the usual post-install steps (governor, overclock, swap, CU unlock). The docs mentioned a couple of them in passing but never collected them, so a reader doing a fresh install couldn't find the fast path.

Covered:
- **Bazzite:** NexGen-3D-Printing/SteamMachine, samedayhurt/bc250-buddy, NeOdYmS/bazzite-bc250-toolkit
- **CachyOS:** redbeard1083/bc250-toolkit (notes the Limine bootloader requirement)
- **Arch:** pnbarbeito/bc250-arch, Boundbygravity/bc250-arch-setup

## Verification status

Pointer-only, no shell commands or tuning values added, so nothing needs hardware testing. Each repo description reflects its own README. The section is explicit that these are third-party, fast-moving, and that the per-distro guides remain the reference.

## Why this and not more

Kept to references. Folding the toolkits' actual tweaks (zswap, swap tuning, OC profiles) into our own steps is a separate change that needs verification on a board first.