### PR TITLE
Update small CPU details

### DIFF
--- a/docs/gaming/compatibility.md
+++ b/docs/gaming/compatibility.md
@@ -4,7 +4,7 @@ Community-tested games with performance data and known issues for the BC-250.
 
 ## Performance Overview
 
-The BC-250 delivers solid 1080p gaming performance, comparable to an RX 6600 or GTX 1660 Ti.
+The BC-250 delivers solid 1080p gaming performance, comparable to a RX 5600 XT or GTX 1660 Ti (6600 XT / RTX 2070 when unlocked).
 
 **Typical Performance:**
 - **1080p High Settings:** 60-100+ FPS in most titles

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -44,7 +44,6 @@ With proper Linux setup, the BC-250 delivers performance comparable to:
 - **No hardware video encode/decode** — VCN firmware is blocked by Sony, software decoding only
 - Audio over DisplayPort can be unreliable with some adapters (passive adapters usually work)
 - No built-in WiFi/Bluetooth (USB adapters work)
-- Limited instruction set (some AVX features missing)
 - High idle power consumption (~50-80W without optimization)
 
 !!!danger "Do NOT Use Smokeless_UMAF"

--- a/docs/hardware/specifications.md
+++ b/docs/hardware/specifications.md
@@ -12,10 +12,11 @@ The BC-250 features a cut-down PS5 APU (codenamed "Oberon" / "Cyan Skillfish"):
 - **Base Clock:** ~3.5 GHz
 - **Architecture:** Zen 2 microarchitecture
 - **Instruction Set:** x86-64
-- **Cache:** Shared L3 cache (reduced from PS5 config)
+- **Cache:** 8 MB L3 cache (4 MB per 3-core cluster)
+- **FPU:** [Reduced FPU throughput](https://chipsandcheese.com/p/the-nerfed-fpu-in-ps5s-zen-2-cores)
 
 !!!info "CPU Performance"
-    The CPU is intentionally cut down for mining purposes. While adequate for gaming and general computing, it's not the board's primary strength.
+    The CPU is intentionally cut down for mining purposes. While adequate for gaming and general computing, it's not the board's primary strength. 
 
 ### GPU Specifications
 

--- a/docs/hardware/specifications.md
+++ b/docs/hardware/specifications.md
@@ -204,7 +204,7 @@ The BC-250 features a cut-down PS5 APU (codenamed "Oberon" / "Cyan Skillfish"):
 - **Memory:** 16GB total (configurable split) vs 8GB dedicated VRAM
 
 !!!success "Gaming Performance"
-    For 1080p gaming, the BC-250 performs admirably, achieving 60+ FPS in most modern games at high settings.
+    For 1080p gaming, the BC-250 performs reasonably, achieving 60+ FPS in most modern games at high settings.
 
 ## Verification Commands
 


### PR DESCRIPTION
The PS5's CPU doesn't have less instructions, it has less throughput compared to a Zen 2 core. The effect on games should be minimal.