### PR TITLE
Add 8 Core CPU Unlock page (SMU msg 0x98)

### DIFF
--- a/docs/bios/flashing.md
+++ b/docs/bios/flashing.md
@@ -21,6 +21,7 @@ While the stock BIOS includes standard features like fan control, the modded BIO
 - **Dynamic VRAM allocation** (512MB setting that auto-allocates between CPU/GPU)
 - **Custom VRAM splits** beyond the stock 8GB/8GB and 12GB/4GB options
 - **Chipset menu** access for advanced configuration options
+- **All 8 CPU cores** (MeiMeiDXE only) — see [8 Core CPU Unlock](../system/8core-unlock.md)
 
 *Note: Actual overclocking is generally not performed via the BIOS on this platform, and fan control is available on both stock and modded versions.*
 
@@ -29,6 +30,7 @@ While the stock BIOS includes standard features like fan control, the modded BIO
 There are two main versions of the modded BIOS floating around the community:
 
 *   **P3.00 Chipset Menu (Recommended):** This is the community standard. It is the most stable and tested version. It successfully unlocks VRAM allocation and chipset settings without introducing unnecessary instability.
+*   **P3.00 MeiMeiDXE-T-v2:** P3.00 with the chipset menu **plus a `Bc250CoreUnlockDxe` driver that enables all 8 CPU cores** at every boot. From [Forbidden-Darkness](https://github.com/Forbidden-Darkness/AMD-BC-250-UEFI-v2.2-Firmware-Menu-Script). Only worth flashing if you want the core unlock permanent — you can try the cores out first from Linux with no flash at all, see [8 Core CPU Unlock](../system/8core-unlock.md). Note it flashes the boot block, so treat it as the highest-risk option here.
 *   **P5.00_clv:** Based on a newer stock code base. It specifically unlocks **Everything**—every hidden menu and setting available. This includes experimental options like ReBAR (Resizable BAR). However, because it exposes critical debug and chipset settings, it is very easy to brick the board if you change the wrong thing. **Stick to P3.00 unless you are an advanced user who knows exactly what they are doing.**
 
 !!!warning "P5.00_clv availability"

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -6,7 +6,7 @@ The AMD BC-250 is an ex-cryptocurrency mining board featuring a cut-down PlaySta
 
 The BC-250 was originally designed for cryptocurrency mining, likely Ethereum, before being repurposed and sold on the surplus market. It features:
 
-- **CPU:** 6x Zen 2 cores running at ~3.5GHz
+- **CPU:** 6x Zen 2 cores running at ~3.5GHz (all 8 cores are [unlockable](../system/8core-unlock.md))
 - **GPU:** 24 RDNA2 Compute Units (codename "Cyan Skillfish")
 - **Memory:** 16GB GDDR6 shared between CPU and GPU
 - **Connectivity:** 1x DisplayPort, 2x USB 3.0, 2x USB 2.0, 1x GbE Ethernet, M.2 NVMe/SATA slot

--- a/docs/hardware/specifications.md
+++ b/docs/hardware/specifications.md
@@ -8,7 +8,7 @@ The BC-250 features a cut-down PS5 APU (codenamed "Oberon" / "Cyan Skillfish"):
 
 ### CPU Specifications
 
-- **Cores:** 6x Zen 2 cores (2 cores disabled from original 8-core design)
+- **Cores:** 6x Zen 2 cores active out of 8 — the two disabled cores are **not fused off** and can be re-enabled, see [8 Core CPU Unlock](../system/8core-unlock.md)
 - **Base Clock:** ~3.5 GHz
 - **Architecture:** Zen 2 microarchitecture
 - **Instruction Set:** x86-64
@@ -185,7 +185,7 @@ The BC-250 features a cut-down PS5 APU (codenamed "Oberon" / "Cyan Skillfish"):
 
 | Feature | BC-250 | PlayStation 5 |
 |---------|--------|---------------|
-| CPU Cores | 6 cores | 8 cores |
+| CPU Cores | 6 cores (8 [unlockable](../system/8core-unlock.md)) | 8 cores |
 | CPU Clock | ~3.5 GHz fixed | Up to 3.5 GHz (variable) |
 | GPU CUs | 24 CUs | 36 CUs |
 | GPU Clock | 2000 MHz max | 2230 MHz (variable) |

--- a/docs/system/8core-unlock.md
+++ b/docs/system/8core-unlock.md
@@ -1,0 +1,177 @@
+# 8 Core CPU Unlock
+
+The BC-250 ships with 6 of its 8 Zen 2 cores active. The other two are **not fused off** — they are masked by a writable SMU register, and flipping that register brings them back. This is the CPU counterpart to the [40 CU Unlock](40cu-unlock.md).
+
+!!!success "Credits"
+    The BIOS-side unlock is the work of **[Forbidden-Darkness](https://github.com/Forbidden-Darkness/AMD-BC-250-UEFI-v2.2-Firmware-Menu-Script)**, whose `MeiMeiDXE-T-v2` mod ships a purpose-built `Bc250CoreUnlockDxe` driver, and of the **BC-250 Telegram community**, who found, tested and documented it. The Linux-side tool and the register documentation on this page come from **[GabriWar](https://github.com/GabriWar/bc250-core-cu-unlock)**, derived by reverse engineering that driver. The matching 8-core ACPI tables are **[mendesrr](https://github.com/mendesrr/bc250-acpi-fix-updated-8c)**'s rebuild of the **[bc250-collective](https://github.com/bc250-collective/bc250-acpi-fix)** fix.
+
+## What It Does
+
+One register controls core availability:
+
+| Register | What it does | Stock | Unlocked |
+|----------|--------------|-------|----------|
+| `SMN 0x0115A870` | CPU core enable bitmask, one bit per core | `0x77` (cores 3 and 7 masked) | `0xFF` (all 8 cores) |
+
+`0x77` is `0b0111_0111` — bits 3 and 7 clear. That is one core disabled per CCX, the symmetric pattern you get from a firmware down-core, not from defect harvesting.
+
+The mask is not writable directly. It is set through an **SMU mailbox command, message `0x98`**, reached over SMN via the PCI config index/data pair `0xB8`/`0xBC` on device `00:00.0`:
+
+```
+SmnWrite32(0x3B10A80, 0)           # clear response register
+SmnWrite32(0x3B10A88, 0x115A870)   # arg0 = target register
+SmnWrite32(0x3B10A8C, 0)           # arg1
+SmnWrite32(0x3B10A20, 0x98)        # message id
+poll 0x3B10A80 until == 1 (ok) or 0xFC..0xFF (error)
+```
+
+CPU topology is fixed by firmware at reset, so the cores do not appear until the platform re-enumerates.
+
+!!!important "Warm reset keeps it, cold boot loses it"
+    | reset | result |
+    |---|---|
+    | **warm** (`reboot`, `systemctl reboot`) | mask preserved → cores stay unlocked |
+    | **cold** (`poweroff`, PSU switch, unplug) | mask reverts to `0x77` → back to 6 cores |
+
+    Nothing is written to flash by the Linux method, so **cutting power is a guaranteed way back to a stock 6-core machine** if anything misbehaves.
+
+## Two Ways To Do It
+
+### Method 1: Linux (no BIOS flash)
+
+Applies the unlock at boot and warm-reboots once so firmware re-enumerates. Reverted by any cold boot, which is also its safety net.
+
+```bash
+git clone https://github.com/GabriWar/bc250-core-cu-unlock
+cd bc250-core-cu-unlock
+
+sudo ./bc250-8core-unlock.sh status     # show the current mask
+sudo ./bc250-8core-unlock.sh apply      # unlock now, then: sudo reboot
+sudo ./bc250-8core-unlock.sh install    # persist: installs and enables a systemd unit
+```
+
+The optional systemd unit re-applies the mask after a cold boot. **It never reboots for you** — the cores appear on your next reboot, whenever you choose to do one.
+
+!!!danger "Do not have anything reboot for you here"
+    An earlier version of that tool rebooted automatically so firmware would re-enumerate in the same session. On a real board it **bootlooped**: the reset it triggered did not preserve the mask, so every boot read `0x77`, re-applied and reset again. Both intended safeguards also failed — an attempt counter under `/var` (not reliably writable that early in boot) and `systemctl reboot` (cannot work before D-Bus is up). Set the mask, then let the user choose when to reboot.
+
+Requires `pciutils` (`setpci`) and root.
+
+### Method 2: BIOS flash (permanent, no extra reboot)
+
+The `MeiMeiDXE-T-v2` mod contains `Bc250CoreUnlockDxe`, which performs the same SMU sequence pre-OS on every boot, so there is no double-boot and nothing to install in the OS. Get it from [Forbidden-Darkness/AMD-BC-250-UEFI-v2.2-Firmware-Menu-Script](https://github.com/Forbidden-Darkness/AMD-BC-250-UEFI-v2.2-Firmware-Menu-Script) and follow the [BIOS Flashing Guide](../bios/flashing.md).
+
+!!!warning "This is a P3.00-based mod"
+    It is built on P3.00 and flashes the boot block. If you are running P5.00 or a different mod, this is a downgrade and you will lose whatever that mod unlocked. Have a [hardware programmer and a verified backup](../bios/recovery.md) before flashing. If you only want to try the cores out, use Method 1 first — it cannot brick anything.
+
+## Are The Extra Cores Healthy?
+
+**On the board tested, yes — completely.** This looks like market segmentation rather than defect harvesting.
+
+Per-physical-core `stress-ng --cpu-method all --verify` (20 s each). `--verify` validates the *result* of each computation, so a marginal core shows up as wrong answers rather than merely lower throughput:
+
+| core | bogo-ops/s | vs median | verify failures |
+|---|---|---|---|
+| 0 | 1526.19 | +0.0% | 0 |
+| 1 | 1526.74 | +0.1% | 0 |
+| 2 | 1529.30 | +0.2% | 0 |
+| **3** | **1530.10** | **+0.3%** | **0** |
+| 4 | 1524.21 | −0.1% | 0 |
+| 5 | 1525.53 | +0.0% | 0 |
+| 6 | 1522.13 | −0.2% | 0 |
+| **7** | **1524.00** | **−0.1%** | **0** |
+
+Cores 3 and 7 are the newly unlocked ones. Whole-die spread is ±0.3%, which is measurement noise — core 3 was in fact the fastest core on the die. A 60 s all-16-thread `--verify` run passed with zero failures and zero machine-check events.
+
+The repo ships `test-cores.sh` to run this sweep on your own board. As with the CU unlock, silicon lottery applies and this is a single board — any core reporting verify failures is producing wrong results and should not be trusted.
+
+## Performance
+
+7-zip multithreaded benchmark on the tested board:
+
+| Config | 7-zip total MIPS |
+|---|---|
+| 6 cores, CPU OC at 3800 MHz | 53,610 |
+| **8 cores, stock clocks** | **68,039** |
+
+That is **+26.9%**, and the comparison is conservative rather than flattering: the 6-core baseline was overclocked while the 8-core run was at stock clocks. It is not a clock-matched A/B, so treat it as indicative.
+
+Scaling is best in threaded workloads. Anything memory-bound is still limited by the 450 MHz FCLK, which this does not change.
+
+## Known Issues
+
+- **GPU frequency reporting breaks.** After unlocking, `pp_dpm_sclk` reports nonsense (for example `1: 15Mhz` where it should read `1500Mhz`) and `gpu_busy_percent` may return empty. The GPU still clocks correctly according to your [governor](governor.md) curve — this is a monitoring bug, not a performance one. Reported by the BC-250 Telegram community and reproduced on the tested board.
+- **Your ACPI tables need updating.** The 6-core SSDTs leave CPUs 12-15 without C-states — see [below](#acpi-tables-must-be-updated-too).
+- **Any existing overclock or undervolt is no longer valid.** See [below](#your-overclock-needs-re-validating).
+- **Other mask values may exist.** Every board checked so far reads `0x77`, but a board that masks a different pair of cores would read something else. The Linux tool refuses to act on any mask it does not recognise rather than guessing.
+
+## ACPI Tables Must Be Updated Too
+
+!!!warning "The 6-core ACPI fix leaves 4 threads with no C-states"
+    If you use the community [ACPI fix](https://github.com/bc250-collective/bc250-acpi-fix), its tables are wrong for an 8-core machine and you should update them.
+
+`SSDT-CST.aml` declares one processor object per **thread**. The 6-core tables stop at `C00B` — 12 threads. Unlock all 8 cores and you have 16, so **CPUs 12-15 receive no cpuidle states at all**: they cannot enter any C-state and burn power at idle.
+
+Measured on the tested board, before updating the tables:
+
+```
+cpu0:  4 idle states
+cpu6:  4 idle states
+cpu12: 0 idle states   <-- no C-states
+cpu14: 0 idle states
+cpu15: 0 idle states
+```
+
+The 8-core rebuild by **[mendesrr](https://github.com/mendesrr/bc250-acpi-fix-updated-8c)** extends the declarations to `C00F`, covering all 16 threads. That repo's README has the install steps for Bazzite, SteamOS and CachyOS.
+
+On Arch/CachyOS the short version is:
+
+```bash
+sudo mkdir -p /etc/initcpio/acpi_override/
+cd /etc/initcpio/acpi_override/
+sudo wget https://github.com/mendesrr/bc250-acpi-fix-updated-8c/raw/refs/heads/main/SSDT-CST.aml \
+          https://github.com/mendesrr/bc250-acpi-fix-updated-8c/raw/refs/heads/main/SSDT-PST.aml
+sudo mkinitcpio -P
+sudo reboot
+```
+
+Back up any existing `.aml` files **outside** `/etc/initcpio/acpi_override/` first. The `acpi_override` hook globs `*.aml` there, so a stray copy alongside the new ones would load two sets of tables.
+
+Check it worked:
+
+```bash
+cpupower idle-info
+# every CPU, including 12-15, should now report C-states
+```
+
+## Your Overclock Needs Re-validating
+
+Two extra cores change the electrical and thermal behaviour of the whole SoC. A curve tuned at 6 cores is not a curve that holds at 8, and the failure mode is not a clean error — it is intermittent instability that reads like a bad game, a bad driver or a bad kernel.
+
+- **Load-line droop gets worse.** Eight cores pulling current sag the rail further than six at the same requested voltage. A voltage that was marginal-but-stable at 6 cores can land under the silicon's floor at 8 during an all-core transient. Undervolts break first.
+- **Thermals rise.** Measured on the tested board: **82.4 °C Tctl at stock clocks** under a 16-thread load, before any overclock.
+- **The shared budget shifts.** CPU and GPU draw from one SoC power and thermal envelope. Two more cores take a bigger slice, leaving the GPU less headroom than it had. If you have also done the [40 CU Unlock](40cu-unlock.md), both ends now compete harder.
+- **Your sweet spot moves.** Peak-throughput frequency, the efficiency knee, and the point where more clock stops buying anything are all functions of the thermal envelope — and that envelope just changed.
+
+After unlocking, redo the work in this order:
+
+1. **Per-core correctness** on all 8 cores (`test-cores.sh`) before tuning anything.
+2. **Re-benchmark** and find the new plateau. Frequencies that paid off at 6 cores may sit past the knee at 8.
+3. **Re-check droop** — measure actual voltage under an all-core load, not at idle, and compare against what you asked for. Widen the margin wherever it sagged.
+4. **Re-cliff the undervolt** at 8 cores. Do not carry the old curve across.
+5. **Re-validate thermals** under sustained load rather than a burst, with CPU and GPU loaded *together* — the co-load case is where the shared envelope actually bites.
+
+Treat your old numbers as a starting hypothesis, not a configuration.
+
+## Verifying
+
+```bash
+lscpu | grep -E 'Core\(s\) per socket|^CPU\(s\)'
+# Core(s) per socket:  8
+# CPU(s):              16
+
+sudo ./bc250-8core-unlock.sh status
+# SMN 0x0115A870 = 0xFF  enabled=[0 1 2 3 4 5 6 7] disabled=[]
+```
+
+If the mask reads `0xFF` but `lscpu` still shows 6 cores, firmware has not re-enumerated yet — warm reboot.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,6 +151,7 @@ nav:
   - System Configuration:
     - GPU Governor: system/governor.md
     - 40 CU Unlock: system/40cu-unlock.md
+    - 8 Core CPU Unlock: system/8core-unlock.md
     - Sensors & Monitoring: system/sensors.md
     - Power Management: system/power.md
 


### PR DESCRIPTION
The BC-250's two disabled CPU cores are **not fused off**. They are masked by a writable SMU register, and the community BIOS mod flips it — so this belongs alongside the 40 CU Unlock page.

## What this adds

**New page:** `docs/system/8core-unlock.md` (+ nav entry under System Configuration)

- `SMN 0x0115A870` is a core-enable bitmask: `0x77` stock (cores 3 and 7 masked) → `0xFF` for all eight
- Written via **SMU mailbox message `0x98`**, over SMN through PCI config `0xB8`/`0xBC` on `00:00.0` — full sequence documented
- **Warm reset preserves the mask, cold boot reverts it.** That makes cutting power a guaranteed way back to a stock 6-core machine
- Two routes: a Linux tool (no flash, revertible) or the MeiMeiDXE BIOS mod (permanent)
- An explicit warning not to let anything auto-reboot to apply the mask — see below
- Core health data, known issues, and a section on why an existing OC/undervolt curve must be re-validated

## Corrections to existing pages

`specifications.md` and `introduction.md` both presented 6 cores as a fixed property of the hardware ("2 cores disabled from original 8-core design"). Reworded to note they are unlockable, with links.

`bios/flashing.md` gains the MeiMeiDXE-T-v2 mod in "Available Modded Versions", flagged as the highest-risk option since it writes the boot block, and pointing readers at the no-flash Linux route first.

## Correction since opening this PR

The page originally described the Linux tool's systemd unit as auto-rebooting once to make firmware re-enumerate, "capped at two attempts so it cannot loop". **That was wrong and it bootlooped my board.** The reset it triggered did not preserve the core mask, so every boot read `0x77`, re-applied and reset again — and both safeguards failed too (the attempt counter lives under `/var`, not reliably writable that early; and `systemctl reboot` cannot work before D-Bus is up).

The tool no longer reboots under any circumstance, and the page now carries a `!!!danger` box documenting the failure mode so nobody reimplements it. Reported here rather than quietly amended, since the earlier wording was live on this PR.

## On sourcing

Per CONTRIBUTING, marking clearly what is tested vs reported:

**Tested on one board** (kernel 7.0.12, CachyOS): the register values and SMU sequence, the warm-vs-cold behaviour, per-core `stress-ng --verify` health across all 8 cores (zero failures, ±0.3% spread), 7-zip throughput, and the GPU-frequency-reporting regression.

**Not tested by me:** the BIOS-flash route. That is described from the mod itself and community reports, and labelled as such.

Single board, so the page says so explicitly and ships a `test-cores.sh` for others to check their own silicon — same silicon-lottery caveat the 40 CU page carries.

## Also covers the ACPI side

Worth flagging separately because it bites anyone already running the community ACPI fix: `SSDT-CST.aml` declares one processor object per **thread**, and the 6-core tables stop at `C00B` (12 threads). After unlocking you have 16, so **CPUs 12-15 get no cpuidle states at all**. Confirmed on hardware:

```
cpu0:  4 idle states
cpu6:  4 idle states
cpu12: 0 idle states
cpu14: 0 idle states
cpu15: 0 idle states
```

The page points at [mendesrr/bc250-acpi-fix-updated-8c](https://github.com/mendesrr/bc250-acpi-fix-updated-8c), which extends the declarations to `C00F`, and notes the gotcha that the `acpi_override` hook globs `*.aml` so backups must live outside that directory.

## Credits

The unlock is the work of **[Forbidden-Darkness](https://github.com/Forbidden-Darkness/AMD-BC-250-UEFI-v2.2-Firmware-Menu-Script)** (the `Bc250CoreUnlockDxe` driver in MeiMeiDXE-T-v2) and of the **BC-250 Telegram community**, who found and tested it. The register documentation here came from reverse engineering that driver; the Linux tool is at [GabriWar/bc250-core-cu-unlock](https://github.com/GabriWar/bc250-core-cu-unlock). The 8-core ACPI tables are [mendesrr](https://github.com/mendesrr/bc250-acpi-fix-updated-8c)'s rebuild of the [bc250-collective](https://github.com/bc250-collective/bc250-acpi-fix) fix.

Happy to adjust tone, structure or scope to fit the rest of the docs.


