### PR TITLE
docs: correct the DP audio root cause and add a no-build fix

### DIFF
--- a/docs/troubleshooting/audio.md
+++ b/docs/troubleshooting/audio.md
@@ -1,120 +1,120 @@
-# DisplayPort Audio: Desync, Delay and Crackle
+# DisplayPort Audio: Silence, Desync or Slow Pitch
 
-Audio over the BC-250's DisplayPort output can arrive late, at a low pitch, or with periodic crackle, while video stays perfect. How bad it gets varies a lot from board to board, from a drift you have to look for up to audio that is unusable. This page explains the actual root cause (a spread-spectrum bug in the display driver, specific to this GPU), how to tell it apart from an adapter problem, and how to fix it.
+Audio over the BC-250's DisplayPort output can be completely silent, or play slightly slow (late, at a low pitch, with periodic crackle) while video stays perfect. Both are the same bug: the board firmware programs the DisplayPort audio clock for a reference clock the hardware does not have. This page explains the mechanism, how to measure it in two minutes, and a fix that needs no kernel build.
 
-This is a different problem from [active DP-HDMI adapters breaking audio](display.md#special-case-active-vs-passive-adapters). That one is about the adapter re-encoding the stream. The one on this page is in the kernel and affects the DisplayPort output itself, so it can show up even on a native DP monitor or a passive adapter.
+This is also the real story behind ["active DP-HDMI adapters break audio"](display.md#special-case-active-vs-passive-adapters). The adapters were never at fault. Passive adapters route audio through a different, unaffected clock path, which is why they seem immune (details below).
 
 ---
 
 ## Symptoms
 
-- Audio and video out of sync, with audio falling further behind the longer you play. Reported severity ranges from a drift of 100 to 200 ms up to a constant rate error that accumulates without bound
-- Audio pitch too low, from barely noticeable to obvious
-- Periodic crackle or clicking as the audio buffer drifts
-- Video is unaffected
+- No audio at all. Most often through an active DP-HDMI adapter or a strict TV/AVR chain that refuses to lock to the off-spec stream
+- Audio plays but runs ~17.65% slow: out of sync (drifting further behind the longer it plays), pitch slightly low, periodic crackle. A 30.00 s file takes 36.46 s
+- Video playback stutter that looks like a network or GPU problem. PipeWire clocks its whole graph off the DisplayPort sink, so a sink draining at ~39.5 kHz stalls video that is synced to audio
+- Everything *looks* healthy: `eld_valid 1`, `hw_params` reports `rate: 48000`, PipeWire shows the sink, xrun counters stay at zero
 
-If instead you get no audio at all on an active adapter, that is the adapter issue, not this one. See [Active vs Passive Adapters](display.md#special-case-active-vs-passive-adapters).
-
-!!!note "How large the error can get"
-    On one board ([#39](https://github.com/elektricM/amd-bc250-docs/issues/39)) the DisplayPort audio clock runs at 39 526 Hz while ALSA reports 48 000 Hz, a constant -17.7 % rate error measured three independent ways. At that magnitude a 30 s file takes 36.5 s and video is a full second behind after five seconds of playback. Display mode and sample rate made no difference. If your symptoms are that severe, this is still the same bug and not a separate one.
+Whether you get silence or slow audio depends on the sink. Some displays play the off-spec stream honestly (slow), others never lock (silent). Same register, same fix.
 
 ---
 
 ## Root cause
 
-The BC-250's Cyan Skillfish GPU is the only shipping AMD GPU that uses the **DCN201** display block, so this code path is effectively BC-250 only.
+The audio digital timing oscillator (DTO) for the DisplayPort path divides the DP reference clock down to 24 MHz using a phase/module register pair. The firmware programs the module value for a reference clock of 728.631 MHz, but the actual DPREFCLK on the BC-250 is 600.000 MHz:
 
-The DisplayPort reference clock is programmed with spread spectrum applied, even though the board firmware says DisplayPort spread spectrum should be off. DisplayPort audio is clocked off that same reference, so dithering the reference clock dithers the recovered audio sample clock. Video tolerates the dither, audio timing does not.
+| Register (DCN 2.0.1) | dword index | Value | Meaning |
+|---|---|---|---|
+| `DCCG_AUDIO_DTO_SOURCE` | `0x16B` | `0x00100010` | `DTO_SEL`=1 → DTO1, the DisplayPort path |
+| `DCCG_AUDIO_DTO1_PHASE` | `0x16E` | `240000` | 24.000 MHz target |
+| `DCCG_AUDIO_DTO1_MODULE` | `0x16F` | **`7286310`** | assumes reference = **728.631 MHz** |
+| `CLK4_CLK2_CURRENT_CNT` | `0x1B27F` | **`6000`** | actual reference = **600.000 MHz** |
 
-The chain, confirmed against the mainline kernel source:
+The audio codec therefore gets `600.000 MHz × 240000/7286310 = 19.763 MHz` instead of 24.000 MHz, and every sample rate is scaled by `600000/728631 = 0.82346`:
 
-1. `dcn201_clk_mgr.c`, `dcn201_clk_mgr_construct()` sets `dprefclk_ss_percentage = 0`, then calls `dce_clock_read_ss_info()` at the end of the function with no condition.
-2. `dce_clock_read_ss_info()` (in `dce_clk_mgr.c`) queries the VBIOS. The GPU-PLL query returns unsupported on this VBIOS revision, so it falls through to the DisplayPort query.
-3. `bios_parser2.c`, `get_ss_info_v4_2()` returns `smu_info->gpuclk_ss_percentage` (the GPU core clock's spread spectrum, a nonzero value like `0x0177`) for the DisplayPort query.
-4. That nonzero percentage is applied to the DisplayPort reference clock in `dce_adjust_dp_ref_freq_for_ss()`, which shifts the audio clock.
+```text
+48000 Hz × 0.82346 = 39526 Hz   predicted
+                     39525-39526 Hz   measured, on two different boards
+```
 
-The VBIOS field that actually says "DisplayPort spread spectrum is off" (`integrated_info->dp_ss_control = 0`) is read in `dcn201_link_init()` and honored for link training, but the clock manager never looks at it. That mismatch is the bug.
+The factor is constant and proportional: identical across 32k/44.1k/48k/96k/192k and across every display mode. The wrong value is written by the **board firmware**, not the driver, and it is restored on **every modeset** (resolution change, game launch, fullscreen toggle). Confirmed independently on two boards by register read plus measuring the real ALSA consumption rate (recipe below). Writing the correct value restores audio instantly, verified at 3840x2160@60 and 1920x1080@120.
 
-!!!note "Not fixed in mainline as of kernel 7.1.x"
-    Earlier notes here said this was resolved in 6.19.10 or newer. That refers to downstream community kernels (patched Bazzite / CachyOS builds), not mainline. Mainline 7.1.3 still calls `dce_clock_read_ss_info()` unconditionally in `dcn201_clk_mgr_construct()`, so the desync is present. A cleaner fix that gates the call on `dp_ss_control` was being prepared for the kernel mailing list at the time of writing but is not merged yet. Verify per kernel rather than trusting a version number (see below).
+!!!note "This replaces the earlier spread-spectrum explanation"
+    This page previously attributed the desync to `dcn201_clk_mgr_construct()` reading GPU-clock spread spectrum into the DP reference clock. That code path exists, but it is not what causes this: patching the shipped `amdgpu` so `dce_clock_read_ss_info()` is never called changes nothing (39526.1 Hz before and after), the spread-spectrum arithmetic predicts a value 0.19% *low* (5988750) where the measured value is 21.4% *high* (7286310), and every driver-computed module value is a multiple of 1000, which 7286310 is not. See [issue #39](https://github.com/elektricM/amd-bc250-docs/issues/39) for the full falsification. Consequently **no kernel version fixes this**; the earlier "fixed in 6.19.10+" note was wrong.
+
+### Why passive adapters seem fine and active adapters seem broken
+
+`decide_signal_from_strap_and_dongle_type()` in the driver (`dc/link/link_detection.c`) treats a passive DP++ dongle as an HDMI sink: the signal becomes `SIGNAL_TYPE_HDMI_TYPE_A` and audio is clocked from **DTO0**, derived from the pixel clock, which this bug cannot touch. An active adapter is a real DisplayPort sink, so audio comes from the broken **DTO1** path, same as a native DP monitor.
+
+So "passive works, active doesn't" is not an adapter quality problem. It was proven directly: with an active adapter silent, disconnecting the sound bar and switching the TV to its own speakers changed nothing, and one register write brought audio back instantly through the same active adapter, with nothing else touched.
 
 ---
 
 ## Diagnosis
 
-First confirm the audio sink exists and is valid. On a working DisplayPort link you get a present, valid ELD:
+Measure the real sample consumption rate. No root, no tools:
 
 ```bash
-aplay -l
-# card 0: Generic [HD-Audio Generic], device 3: HDMI 0 [<your monitor name>]
+# Find the running playback substream while audio "plays" (sound card index varies per boot):
+for s in /proc/asound/card*/pcm*p/sub*/status; do grep -q RUNNING "$s" && echo "$s"; done
 
-cat /proc/asound/card*/eld*
-# monitor_present   1
-# eld_valid         1
-# connection_type   DisplayPort
+# Read hw_ptr from that file twice, ~10s apart. Real rate = (hw_ptr2 - hw_ptr1) / seconds.
+# Bug present:  ~39525 Hz while hw_params says rate: 48000
+# Bug absent:   ~48000 Hz
 ```
 
-If `eld_valid` is `1` and the audio format looks correct, but you still hear the delay, pitch or crackle, that points at the reference-clock spread spectrum rather than the adapter or the EDID.
+`aplay -l`, the ELD, `hw_params`, the PipeWire sink list and xrun counters all read identical whether audio works or not, so don't spend time on them:
 
-!!!warning "An error count of zero does not rule this out"
-    This bug produces no xruns, so every standard health check looks clean while the crackle continues. The sink never runs dry, the source overflows: the application produces 48 000 frames per second and only around 39 500 drain, so the surplus is discarded. `pw-top` sits at `ERR 0` forever. Do not use xrun counters to rule this out, measure the actual rate instead. Reported in [#39](https://github.com/elektricM/amd-bc250-docs/issues/39).
+- `hw_params` reports the *configured* rate, not the clock actually ticking.
+- `eld connection_type: DisplayPort` proves nothing; the kernel fills it from the connector type alone.
+- xruns stay at 0 because the sink isn't underrunning. The *source* is overrunning, and PipeWire silently discards the surplus samples; `pw-top` sits at `ERR 0` indefinitely while the problem continues.
 
-Capture the EDID with `cat`, not a file-manager copy (copying a sysfs file gives a 0-byte result):
+To confirm at the register level (root required), read the four dword indices from the table above via `/sys/kernel/debug/dri/<n>/amdgpu_regs`, or with umr.
 
-```bash
-cat /sys/class/drm/card*-DP-1/edid > ~/edid
-edid-decode ~/edid   # look for the Audio Data Block and sample rates
-```
-
-While audio is playing, the negotiated stream parameters confirm the format actually in use:
-
-```bash
-cat /proc/asound/card*/pcm*p/sub*/hw_params   # rate, format, channels during playback
-```
-
-### Is the fix in my kernel?
-
-Version numbers are unreliable here because the fix has only lived in downstream kernels so far. Check the source directly. `kernel-devel` ships headers only, so you need the matching kernel source tree (for example from `dnf download --source kernel` or your distro's kernel-source package):
-
-```bash
-grep -n dp_ss_control <kernel-source>/drivers/gpu/drm/amd/display/dc/clk_mgr/dcn201/dcn201_clk_mgr.c
-```
-
-If `dcn201_clk_mgr_construct()` guards `dce_clock_read_ss_info()` with a `dp_ss_control` check, the fix is present. If the call is unconditional, it is not.
+!!!warning "umr pitfalls on this ASIC"
+    If you use umr on the BC-250: the display IP block is named `dcn203`, **not** `dcn201`, and an explicit `dcn201` register path fails. Only the `DCCG_AUDIO_DTO*` registers read back truthfully; umr's `DIG*`/`DP*` names map to wrong offsets on this ASIC and report "audio muted / no packets" even while audio plays perfectly. And `umr --write` interprets the value as **hex**, so writing decimal `6000000` actually writes `0x6000000` = 100663296. Never pass a `*` wildcard path to a write.
 
 ---
 
-## Fixes
+## Fix (no kernel build)
 
-### Hardware workarounds (no rebuild)
+Writing the correct module value takes effect immediately, even on a running stream. The correct value is derived from the hardware itself: `CLK4_CLK2_CURRENT_CNT × 1000` (6000 → 6000000 on this board). Because every modeset restores the wrong value, and Steam Game Mode changes resolution on every game launch, the write has to be re-applied by a small watcher service:
 
-These sidestep the bug rather than fixing it:
-
-- A passive DP-to-HDMI adapter or a native DisplayPort monitor keeps things simplest.
-- A USB DAC moves audio off DisplayPort entirely, which is the reliable route if you cannot rebuild the kernel.
-
-### Kernel patch (the actual fix)
-
-There is no runtime knob. `ignore_dpref_ss` is a `dc_config` field, not a module parameter and not reachable through `amdgpu.dcdebugmask`, so the fix needs a rebuilt amdgpu module or kernel.
-
-The patch clears the DisplayPort spread spectrum when the firmware says it is off. Applied to `dcn201_clk_mgr_construct()`:
-
-```c
--    dce_clock_read_ss_info(clk_mgr);
-+    /* BC-250: get_ss_info_v4_2() reports the shared GPU-clock spread spectrum
-+     * on the DisplayPort query, which desyncs DP audio. Only read DP-ref SS
-+     * when the VBIOS says DP spread spectrum is enabled. */
-+    if (bp->integrated_info && bp->integrated_info->dp_ss_control)
-+        dce_clock_read_ss_info(clk_mgr);
+```python
+#!/usr/bin/python3
+import glob, os, time
+IDX_SRC, IDX_PHASE, IDX_MOD, IDX_CLK = 0x16B, 0x16E, 0x16F, 0x1B27F
+fd = os.open(glob.glob('/sys/kernel/debug/dri/*/amdgpu_regs')[0], os.O_RDWR)
+rd = lambda i: int.from_bytes(os.pread(fd, 4, i * 4), 'little')
+while True:
+    src, phase, mod, clk = rd(IDX_SRC), rd(IDX_PHASE), rd(IDX_MOD), rd(IDX_CLK)
+    want = clk * 1000                  # counter is 100 kHz units, module wants kHz*10
+    if (src >> 4) & 3 == 1 and phase == 240000 and 4_000_000 <= want <= 12_000_000 \
+            and mod != want:
+        os.pwrite(fd, want.to_bytes(4, 'little'), IDX_MOD * 4)
+    time.sleep(1)
 ```
 
-Building a patched amdgpu module follows the same flow as the [40 CU unlock](../system/40cu-unlock.md) build (kernel source, patch, compile, rebuild the initramfs). If you already rebuild the module for the 40 CU unlock, add this patch in the same pass. This patch has not been tested on our reference board yet, so treat the exact build steps as reported rather than verified here.
+The guard only acts when DTO1 (the DisplayPort path) is selected at the expected 24 MHz phase, so HDMI-TMDS via a passive adapter is deliberately left alone, and the service is safe to leave enabled across display swaps. Run it as a systemd service (`Type=simple`, `WantedBy=multi-user.target`).
 
-!!!warning "Reverts on kernel update"
-    Like the 40 CU unlock, a patched out-of-tree module is reverted by every kernel update. You rebuild after each update, or pin your kernel.
+Two service-setup mistakes that cost real debugging time:
+
+- Do **not** combine `After=graphical.target` with `WantedBy=multi-user.target`. That is an ordering cycle, and systemd silently deletes the service's start job at boot. It is invisible when you test with a manual `systemctl start`.
+- On Fedora Atomic / Bazzite, install the script to `/usr/local/bin` and point the unit there. SELinux denies systemd (`init_t`) execute on files in `/home` (`user_home_t`), producing a `203/EXEC` crash loop.
+
+!!!note "Up to one second of wrong audio after a modeset"
+    The firmware rewrites the register on each modeset and the watcher corrects it on its next pass. With a 1 s interval that means up to a second of silent or slow audio after a resolution change or game launch, then it recovers on its own.
+
+If you cannot or don't want to run the watcher: a passive DP-to-HDMI adapter (DTO0 path) or a USB DAC sidesteps the bug entirely.
+
+---
+
+## Pitfalls when testing
+
+- **Check the default sink before concluding the fix failed.** If audio was broken for a while, WirePlumber may have saved *Dummy Output* (`auto_null`) as the preferred sink in `~/.local/state/wireplumber/default-nodes`, and audio then stays silent even with the clock fixed. `wpctl status`, then `wpctl set-default` onto the DisplayPort sink. (`speaker-test -D hw:X,Y` bypasses PipeWire, which makes it a good isolation tool.)
+- **Unplugging the HDMI cable at the TV end of an active adapter does not force a modeset.** The adapter is the DP sink and holds the link up regardless of its downstream side. To force a real modeset, change the resolution GPU-side or unplug at the board end.
+- **To test whether an event restores the wrong value, write the correct value first, then trigger the event.** Triggering a modeset while the wrong value is already present overwrites wrong with wrong and looks like "no effect".
 
 ---
 
 ## Credit
 
-Root cause analysis and the DCN201 patch are community work from the BC-250 Discord (Trov, with cross-checking from essdee and mzk10). The code path above was re-confirmed against the mainline kernel source.
+Root cause identification, the spread-spectrum falsification and the watcher approach: **Fleischfrau** in [issue #39](https://github.com/elektricM/amd-bc250-docs/issues/39) (LG TV, native DisplayPort). Independent confirmation on a second board, the active-adapter exoneration, the DTO0/DTO1 passive-vs-active analysis and the umr/service pitfalls: **Elgar Weijtmans** (@Weijtmans), verified at 4K60 and 1080p120 through a UGREEN 8K active DP-HDMI adapter (Realtek RTD2173) → Samsung TV → HDMI-ARC → Sonos Beam, CEC intact, on Bazzite (Fedora Atomic 43), kernel 6.17.7-ba29. The original DCN201 spread-spectrum source analysis this page previously carried was community work by Trov, essdee and mzk10 of the BC-250 Discord; the code path they described is real, it just turned out not to be what programs this register.


### PR DESCRIPTION
Rewrites `troubleshooting/audio.md` around the actual root cause of the DisplayPort audio problem, following up on the falsification in #39.

**What changed**

- Root cause replaced: the board firmware programs `DCCG_AUDIO_DTO1_MODULE` = 7286310 (assumes a 728.631 MHz reference) while the real DPREFCLK is 600.000 MHz (`CLK4_CLK2_CURRENT_CNT` = 6000). Every sample rate is scaled by 0.82346, so 48 kHz plays at ~39526 Hz. The spread-spectrum explanation the page carried is kept as an explicit correction note with the three reasons it fails (patching out `dce_clock_read_ss_info()` changes nothing; wrong direction and magnitude; driver-written module values are always multiples of 1000).
- Symptoms extended: the same bug produces **total silence** on sinks that refuse to lock (my board, through an active adapter chain) and **slow/desynced audio** on sinks that play the off-spec stream honestly (#39's board, native DP). Also documents the secondary symptom that PipeWire-clocked video stutters.
- Explains why passive adapters seem immune and active adapters seem broken: passive DP++ makes the driver pick `SIGNAL_TYPE_HDMI_TYPE_A` and DTO0 (pixel clock), while active adapters and native DP use DTO1. Adapter exonerated by direct test: TV on its own speakers stayed silent, one register write restored audio instantly through the same active adapter.
- Diagnosis section rebuilt around the one measurement that works (real ALSA consumption rate from `hw_ptr`), lists what reads healthy either way (ELD, `hw_params`, xruns), and adds the umr pitfalls specific to this ASIC (`dcn203` block name, false `DIG*`/`DP*` reads, hex-only writes).
- Fix replaced with the no-kernel-build watcher (value derived live from `CLK4_CLK2_CURRENT_CNT`, DTO1-only guard), including two real service-setup traps (systemd ordering cycle, SELinux on Atomic distros) and testing pitfalls.

**Verification**

Independently confirmed on my board before writing this: register read plus `hw_ptr`-vs-wall-clock timing (39525.2 Hz measured, ratio 0.82344 vs 0.82346 predicted; 47996.8-48036 Hz after the fix), at 3840x2160@60 and 1920x1080@120, through a UGREEN 8K active DP-HDMI adapter (Realtek RTD2173) into a Samsung TV with HDMI-ARC to a Sonos Beam, CEC intact. Bazzite (Fedora Atomic 43), kernel 6.17.7-ba29. Numbers match #39's board (LG TV, native DP) to within 1 Hz.

Credit for the root-cause identification and the falsification stays with Fleischfrau (#39); the original Discord spread-spectrum analysis remains credited in the page.

`mkdocs build --strict` passes.