### PR TITLE
docs: active DP-HDMI adapters do not break audio

### DIFF
--- a/docs/hardware/display.md
+++ b/docs/hardware/display.md
@@ -65,39 +65,40 @@ aplay -l
 - **Use Case:** Most users, TV connections
 - **Note:** DP 1.2 max (1440p @60Hz, some support 1440p @165Hz)
 
-**Active Adapters (Use with Caution):**
-- **Audio:** Often broken or unreliable
+**Active Adapters:**
+- **Audio:** Silent out of the box on many setups. Caused by the board's DisplayPort audio clock, not the adapter, and works with the [DP audio clock fix](../troubleshooting/audio.md)
 - **Cost:** More expensive ($15-30)
-- **Use Case:** Only if you need 4K @120Hz+
-- **Issues:** Audio compatibility problems common
+- **Use Case:** 4K @60Hz+ on HDMI displays, HDMI-CEC
+- **Issues:** Apply the audio fix before writing the adapter off
 
 ### Known Issues with Adapters
 
-!!!warning "Audio Problems with Adapters"
-    Many DP to HDMI adapters break audio functionality. This is a known limitation.
+!!!info "The adapters were never the problem"
+    The "adapters break audio" reports trace back to a bug on the board itself: the firmware programs the DisplayPort audio clock for a reference clock the hardware does not have. Active adapters are real DisplayPort sinks, so they receive that off-spec audio stream and often refuse to lock (silence). Passive adapters make the driver use a different, unaffected clock path, which is why they seem immune. See [DisplayPort Audio: Silence, Desync or Slow Pitch](../troubleshooting/audio.md) for the mechanism and a fix that needs no kernel build.
 
 **Common Symptoms:**
-- Display works, no audio
-- Audio works intermittently
+- Display works, no audio (active adapters: the sink refuses the off-spec stream)
+- Audio plays but slow, out of sync, or with periodic crackle (sinks that tolerate it)
 - Audio dropouts/clicking
 
 **Workarounds:**
-1. Use USB audio adapter/DAC
-2. Use 3.5mm audio cable (no audio output on BC-250)
-3. Use Bluetooth audio
-4. Try different adapter brand
+1. Apply the [DP audio clock fix](../troubleshooting/audio.md), which fixes audio through the adapter you already have
+2. Use a passive adapter (unaffected clock path, but 1080p/1440p limits and no CEC)
+3. Use USB audio adapter/DAC
+4. Use Bluetooth audio
 
 ### Tested Adapter Compatibility
 
 | Adapter Type | Display Works | Audio Works | Notes |
 |--------------|---------------|-------------|-------|
+| UGREEN 8K Active (Realtek RTD2173) | Yes | Yes, with the [DP audio clock fix](../troubleshooting/audio.md) | Silent without the fix. Verified at 4K60 and 1080p120; HDMI-CEC works. Tested by @Weijtmans |
 | Generic Passive | Usually | Sometimes | Hit or miss |
 | Cable Matters Active | Yes | No | 4K works, no audio |
 | Club3D Active | Yes | Sometimes | Sporadic audio issues |
 | StarTech Active | Yes | No | Reliable display, no audio |
 
-!!!info "Audio Adapter Limitation"
-    If you need audio, consider a USB audio adapter ($10-20) as a reliable solution.
+!!!note "The 'No audio' rows predate the root cause discovery"
+    The Cable Matters/Club3D/StarTech results were collected before the [DP audio clock bug](../troubleshooting/audio.md) was identified. The mechanism predicts they fail for the same reason and would work with the fix, but that has not been re-tested. If you own one, re-test with the fix applied and report back.
 
 ## Common Display Problems
 
@@ -315,7 +316,7 @@ HDR support in Linux is improving but still experimental:
 
 ## Audio Solutions
 
-Since audio over HDMI adapters is unreliable, here are alternative solutions:
+Audio through DP-HDMI adapters is fixable in software, see the [DP audio clock fix](../troubleshooting/audio.md). If you'd rather not run that, here are alternative solutions:
 
 ### Option 1: USB Audio Adapter
 
@@ -417,7 +418,7 @@ If your monitor has DisplayPort input AND built-in speakers:
 ### TV Connection (Living Room Gaming)
 - **Display:** 4K TV with HDMI 2.0+
 - **Adapter:** Active DP to HDMI 2.0 adapter
-- **Audio:** Use TV speakers (if adapter supports audio) OR Bluetooth/USB audio
+- **Audio:** TV speakers / soundbar over the adapter works with the [DP audio clock fix](../troubleshooting/audio.md); Bluetooth/USB audio as fallback
 - **Note:** Test adapter audio before permanent setup
 
 ## See Also

--- a/docs/troubleshooting/display.md
+++ b/docs/troubleshooting/display.md
@@ -355,24 +355,20 @@ Reduce frequency or increase voltage in governor config.
 - Contains electronics/chip for signal conversion
 - Powered from DP port
 - Supports 4K60Hz, 4K120Hz
-- **Audio does NOT work on BC-250**
+- **Audio:** silent without the [DP audio clock fix](audio.md). The board's fault, not the adapter's
 - Cost: $15-30
 
 ### Known Issues with Active Adapters
 
-!!!warning "Audio Broken on Active Adapters"
-    Active DP-HDMI adapters consistently break audio on BC-250. Video works, audio doesn't.
+!!!info "The silence is the board's audio clock, not the adapter"
+    The BC-250's firmware programs the DisplayPort audio clock ~21% off, so every sample rate comes out ~17.65% slow. An active adapter is a real DisplayPort sink and receives that off-spec stream; most refuse to lock, which reads as "video works, audio doesn't". This was proven adapter-innocent: with an active adapter silent, a single register write restored audio instantly through that same adapter. See [DisplayPort Audio: Silence, Desync or Slow Pitch](audio.md) for the mechanism and the fix.
 
-**Why:** Active adapters re-encode the signal. BC-250's DP audio implementation is non-standard, and active adapters can't properly decode it.
+**Why passive adapters seem immune:** the driver treats a passive DP++ dongle as an HDMI sink and clocks audio from the pixel clock instead of the broken DisplayPort reference clock. A native DP monitor takes the same affected path as an active adapter, but usually plays the stream anyway, just slow and drifting.
 
 **Workarounds:**
-1. Use passive adapter (best solution)
-2. Use USB DAC for audio
-3. Use native DP monitor
-4. Use USB-C headphones
-
-!!!note "Audio delay, low pitch or crackle on a passive adapter or native DP?"
-    That is a separate problem: a spread-spectrum bug in the display driver that affects the DisplayPort output itself, not the adapter. See [DisplayPort Audio: Desync, Delay and Crackle](audio.md).
+1. Apply the [DP audio clock fix](audio.md), which keeps the active adapter and its capabilities (4K60+, CEC)
+2. Use passive adapter (unaffected path, if its resolution limits suit you)
+3. Use USB DAC for audio
 
 ### Recommended Adapters
 
@@ -381,10 +377,9 @@ Reduce frequency or increase voltage in governor config.
 - Cable Matters DP to HDMI adapter
 - Most cheap unbranded passive adapters
 
-**Avoid:**
-- Any adapter advertising "4K120" or "8K"
-- Adapters with USB power ports
-- Adapters with status LEDs (usually active)
+**Active adapters:**
+- "4K120"/"8K"-branded adapters are active adapters: fine for video, but expect no audio until the [DP audio clock fix](audio.md) is applied (a UGREEN 8K unit is verified working with it, including CEC)
+- USB power ports or status LEDs usually indicate an active adapter
 
 ---
 


### PR DESCRIPTION
Corrects the "active DP-HDMI adapters consistently break audio" claim in `hardware/display.md` and `troubleshooting/display.md`. One logical change, the same claim lives on both pages.

**What changed**

- The audio failures blamed on active adapters are the board's DisplayPort audio clock bug (see #43 / #39): the firmware programs the audio DTO ~21% off, active adapters are real DP sinks that receive the off-spec stream, and most refuse to lock. Proven adapter-innocent on my board: with an active adapter completely silent, a single register write restored audio instantly through that same adapter, nothing else changed.
- Explains why passive adapters seem immune (the driver treats a passive DP++ dongle as an HDMI sink and clocks audio from the pixel clock, which this bug cannot touch) and corrects "use a native DP monitor" as an audio workaround, since native DP takes the same affected path as an active adapter.
- Adds a tested-hardware row: UGREEN 8K active DP-HDMI (Realtek RTD2173), video and audio working with the fix, verified at 4K60 and 1080p120, HDMI-CEC working. Flags the existing Cable Matters/Club3D/StarTech "no audio" rows as predating the root-cause discovery, with a call to re-test.
- Softens the "avoid anything advertising 8K" heuristic accordingly.

**Environment:** BC-250, Bazzite (Fedora Atomic 43), kernel 6.17.7-ba29, UGREEN 8K active DP-HDMI into a Samsung TV with an HDMI-ARC soundbar.

Pairs with #43 (the audio.md rewrite this page links to); both build clean independently. `mkdocs build --strict` passes.