### PR TITLE
docs: point rpm-ostree users at the working acpi-fix method

### DIFF
--- a/docs/linux/bazzite.md
+++ b/docs/linux/bazzite.md
@@ -226,6 +226,10 @@ systemctl reboot
 
 ## Post-Installation Configuration
 
+### ACPI Fix (CPU C-States and P-States)
+
+The [ACPI fix](../system/governor.md#acpi-fix-installation) enables CPU idle states and frequency scaling. On Bazzite, follow the **rpm-ostree variant** of Step 2 on that page: the plain-Fedora BLS instructions do not work here, because Bazzite's boot entries are managed by ostree.
+
 ### Temperature Sensors
 
 For **read-only monitoring** (temperatures, voltages, fan speeds):

--- a/docs/system/governor.md
+++ b/docs/system/governor.md
@@ -789,6 +789,23 @@ sudo grub-mkconfig -o /boot/grub/grub.cfg    # Arch
 sudo update-grub                              # Debian
 ```
 
+On Bazzite, Fedora Atomic and other rpm-ostree distros:
+
+The two variants above do not apply here. An ostree system has no `/boot/loader/entries/<machine-id>-<kernel>.conf` (its BLS entries are regenerated `ostree-*.conf` files, and hand edits do not survive the next deployment), which is why the Fedora command opens an empty file. Use the dracut override method already documented on the [Fedora CoreOS page](../linux/fedora-coreos.md#enable-acpi-c-states-and-p-states) instead. Only the `git clone` from Step 1 is needed; skip the cpio archive:
+
+```bash
+sudo mkdir -p /etc/dracut.conf.d/acpi/
+sudo cp bc250-acpi-fix/*.aml /etc/dracut.conf.d/acpi/
+sudo tee /etc/dracut.conf.d/99-acpi-override.conf <<'CONF'
+acpi_override="yes"
+acpi_table_dir="/etc/dracut.conf.d/acpi"
+CONF
+sudo rpm-ostree initramfs --enable
+sudo systemctl reboot
+```
+
+After the reboot, `dmesg | grep SSDT` should report both tables found in the initrd, as shown on the CoreOS page.
+
 **Step 3: Reboot and verify**
 
 ```bash
@@ -808,6 +825,8 @@ echo schedutil | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 
 !!!warning "Kernel Update Note"
     When you update to a new kernel, the BLS entry for the new kernel won't include the ACPI override. You'll need to edit the new entry or automate this with a kernel-install hook.
+
+    This does not apply to the rpm-ostree method: with `rpm-ostree initramfs --enable`, the initramfs is regenerated with the tables on every deployment, so the override persists across updates.
 
 ## Community Resources
 


### PR DESCRIPTION
Closes #48.

The ACPI fix's Step 2 offers Fedora (BLS) or Arch/Debian (GRUB) instructions, and a Bazzite user following the Fedora branch lands in an empty nano buffer, which is exactly what #48 reports: an ostree system has no `/boot/loader/entries/<machine-id>-<kernel>.conf`, its BLS entries are regenerated `ostree-*.conf` files, and hand edits there do not survive the next deployment.

The working method for that family was already on this site, on the [Fedora CoreOS page](https://elektricm.github.io/amd-bc250-docs/linux/fedora-coreos/#enable-acpi-c-states-and-p-states) (dracut override directory plus `rpm-ostree initramfs --enable`), but nothing linked to it. This PR:

- adds an "On Bazzite, Fedora Atomic and other rpm-ostree distros" variant to Step 2 of the governor page's ACPI section, summarizing the CoreOS page's method (with credit and a link) and explaining why the plain-Fedora command opens an empty file,
- extends the Kernel Update Note: the rpm-ostree method is not affected, since the initramfs is regenerated with the tables on every deployment,
- gives `linux/bazzite.md` a short ACPI section under Post-Installation Configuration pointing at the right variant, so Bazzite readers stop guessing between the two existing branches.

The method itself is the one already documented and verified on the CoreOS page; this change connects it to the audience that keeps missing it.

`mkdocs build --strict` passes.
