### PR TITLE
docs: fix links that point at renamed vram headings

### DIFF
--- a/docs/bios/flashing.md
+++ b/docs/bios/flashing.md
@@ -3,7 +3,7 @@
 Flashing the modded BIOS is the recommended way to unlock the BC-250's full potential. It primarily enables **dynamic VRAM allocation** and grants access to **advanced chipset settings** that are hidden in the stock configuration.
 
 !!!tip "Not always required"
-    If your only goal is changing VRAM size, you can do that from Linux on the stock P3.00 / P5.00 BIOS using [bc250_memcfg](https://github.com/fanoush/bc250_memcfg). See [VRAM Configuration](vram.md#changing-vram-allocation) for details. Flashing is only needed if you want the unlocked chipset menus or features beyond VRAM sizing.
+    If your only goal is changing VRAM size, you can do that from Linux on the stock P3.00 / P5.00 BIOS using [bc250_memcfg](https://github.com/fanoush/bc250_memcfg). See [VRAM Configuration](vram.md#changing-the-vram-split) for details. Flashing is only needed if you want the unlocked chipset menus or features beyond VRAM sizing.
 
 !!!danger "Hardware Safety: GPU Power Connector"
     Ensure the 8-pin PCIe power connector is wired correctly BEFORE attempting to flash.

--- a/docs/linux/alpine.md
+++ b/docs/linux/alpine.md
@@ -39,9 +39,9 @@ Alpine Linux works on the BC-250, but setup is more manual than on mainstream de
 Before installing Alpine, ensure BIOS is configured:
 
 1. Flash modified BIOS (P3.00 or later recommended)
-2. Set VRAM allocation to 512MB dynamic (recommended for shared VRAM / UMA, see [VRAM Configuration](../bios/vram.md#option-1-512mb-dynamic))
+2. Set VRAM allocation to 512MB dynamic (recommended for shared VRAM / UMA, see [Dynamic VRAM](../bios/vram.md#dynamic-vram))
 
-For LLM or GPU-compute workloads, consider a fixed split such as [Option 3: 8GB RAM / 8GB VRAM](../bios/vram.md#option-3-fixed-8gb-ram-8gb-vram) or [Option 4: 12GB RAM / 4GB VRAM](../bios/vram.md#option-4-fixed-12gb-ram-4gb-vram), depending on whether you want to prioritize GPU memory or system RAM.
+For LLM or GPU-compute workloads, consider a higher fixed split such as 8GB or 12GB VRAM, depending on whether you want to prioritize GPU memory or system RAM. See [What VRAM Split is Best?](../bios/vram.md#what-vram-split-is-best) for the trade-offs.
 
 See [BIOS Flashing Guide](../bios/flashing.md).
 

--- a/docs/system/sensors.md
+++ b/docs/system/sensors.md
@@ -722,7 +722,7 @@ From Discord testing:
    cd nct6687d && make && sudo make install
    sudo modprobe nct6687 force=true
    ```
-   On atomic/immutable distros `make install` fails because the kernel tree is read-only. See the [Immutable / Atomic Distros](#immutable--atomic-distros-bazzite-silverblue-fedora-coreos) subsection above.
+   On atomic/immutable distros `make install` fails because the kernel tree is read-only. See the [Immutable / Atomic Distros](#immutable-atomic-distros-bazzite-silverblue-fedora-coreos) subsection above.
 
 !!!info "nct6683 vs nct6687"
     `nct6683` is read-only (temperature, voltage, fan speed monitoring). `nct6687` provides full read+write access including PWM fan control. For fan curves and manual speed control, you need `nct6687`.


### PR DESCRIPTION
The vram.md rewrite (#36, #46) renamed the page's headings, and four inbound links still point at the old ones. mkdocs only reports these at INFO level, so the strict build does not catch them; the links land at the top of the page instead of the intended section.

- `linux/alpine.md`: `#option-1-512mb-dynamic` now points at [Dynamic VRAM](https://elektricm.github.io/amd-bc250-docs/bios/vram/#dynamic-vram), and the Option 3/Option 4 sentence (both anchors gone) now links [What VRAM Split is Best?](https://elektricm.github.io/amd-bc250-docs/bios/vram/#what-vram-split-is-best) instead.
- `bios/flashing.md`: `#changing-vram-allocation` corrected to `#changing-the-vram-split`.
- `system/sensors.md`: the self-link to the atomic-distros subsection had a double hyphen in the slug; the slugifier collapses `/` and spaces to a single one.

After this, `mkdocs build --strict` reports zero anchor notes. Since two of the four were orphaned by the vram rewrite I contributed to, this is me cleaning up after it.