### PR TITLE
docs: black screen after idle is a failed s2idle resume

### DIFF
--- a/docs/linux/bazzite.md
+++ b/docs/linux/bazzite.md
@@ -294,6 +294,12 @@ systemctl reboot
 
 ## Known Issues & Solutions
 
+### Box Dead After Sitting Idle
+
+**Symptom:** After a period of inactivity the display is black, no input wakes the box, and it is not reachable over the network. Only a power cut recovers it.
+
+**Cause:** The box auto-suspended, and s2idle resume does not work on this hardware. See [Black Screen After Idle](../troubleshooting/display.md#problem-black-screen-after-idle-nothing-wakes-it) for the diagnosis and fix. Note that Steam Game Mode has its own idle suspend, so masking the suspend targets matters even if the desktop's power settings already say never suspend.
+
 ### Screen Freezes When Loading Levels On Newer Games
 
 **Symptom:** Screen freezes indefinitely when loading in levels on newer games

--- a/docs/troubleshooting/display.md
+++ b/docs/troubleshooting/display.md
@@ -264,6 +264,39 @@ Some active adapters overheat and fail.
 - Switch to passive adapter
 - Ensure adapter has airflow
 
+### Problem: Black Screen After Idle, Nothing Wakes It
+
+**Symptoms:**
+- Display goes black after a period of inactivity
+- No input wakes it: not mouse, keyboard or controller
+- The box is not reachable over the network either
+- Only a power cut recovers it
+
+**Cause: the box suspended and never resumed.** The BC-250 only offers `s2idle` (`cat /sys/power/mem_sleep` shows `[s2idle]` with no `deep` state), and s2idle resume does not work on this hardware. The machine hangs in suspend, which is why no input does anything.
+
+**Confirm it** after the forced reboot by looking at the end of the previous boot's journal:
+
+```bash
+journalctl -b -1 -n 5
+# A last line like "PM: suspend entry (s2idle)" with no resume entry after it
+# means the box suspended and hung there.
+```
+
+**Fix: stop anything from suspending the box.**
+
+```bash
+# GNOME desktop idle suspend:
+gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-ac-type 'nothing'
+
+# System-wide. Also covers Steam Game Mode's own idle suspend,
+# which the desktop setting does not reach:
+sudo systemctl mask sleep.target suspend.target hibernate.target hybrid-sleep.target
+```
+
+Revert with `sudo systemctl unmask sleep.target suspend.target hibernate.target hybrid-sleep.target` if resume ever starts working on this hardware.
+
+Tested by: @Weijtmans. BC-250, Bazzite (Fedora Atomic 43), kernel 6.17.7-ba29.
+
 ---
 
 ## Display Flickering / Artifacts


### PR DESCRIPTION
Adds the one intermittent-black-screen case the existing list does not cover: the box is not overheating or crashing, it suspended and never came back. The BC-250 offers only s2idle and resume does not work on this hardware, so an idle timeout turns into a hang that needs a power cut.

What the new subsection gives:

- The distinguishing symptoms: no input wakes it and the network is dead too, because nothing is running anymore.
- The one-command diagnosis: the previous boot's journal ends at `PM: suspend entry (s2idle)` with no resume line (`journalctl -b -1 -n 5`).
- The fix in two layers: the desktop's idle-suspend setting, plus masking the four suspend targets system-wide, because Steam Game Mode has its own idle suspend that desktop settings do not reach. Revert command included.

Also adds a matching entry to the Bazzite page's Known Issues that links here, since that is where an affected user is likely to look first.

First-party: hit, diagnosed and fixed on the tested board.

`mkdocs build --strict` passes.
