### PR TITLE
docs: cross-link the audio clock bug from performance troubleshooting

### DIFF
--- a/docs/troubleshooting/audio.md
+++ b/docs/troubleshooting/audio.md
@@ -100,6 +100,8 @@ Two service-setup mistakes that cost real debugging time:
 - Do **not** combine `After=graphical.target` with `WantedBy=multi-user.target`. That is an ordering cycle, and systemd silently deletes the service's start job at boot. It is invisible when you test with a manual `systemctl start`.
 - On Fedora Atomic / Bazzite, install the script to `/usr/local/bin` and point the unit there. SELinux denies systemd (`init_t`) execute on files in `/home` (`user_home_t`), producing a `203/EXEC` crash loop.
 
+A maintained version of this watcher, with `status`, `apply`, `revert`, `watch` and `install-service` commands and both pitfalls above handled, is available as `bc250-audio-dto-fix.sh` in [bc250-tools](https://github.com/Weijtmans/bc250-tools).
+
 !!!note "Up to one second of wrong audio after a modeset"
     The firmware rewrites the register on each modeset and the watcher corrects it on its next pass. With a 1 s interval that means up to a second of silent or slow audio after a resolution change or game launch, then it recovers on its own.
 

--- a/docs/troubleshooting/performance.md
+++ b/docs/troubleshooting/performance.md
@@ -519,6 +519,19 @@ default-sample-rate = 48000
 
 For Ryujinx (Switch emulator): Change audio backend in settings can dramatically improve performance.
 
+### Issue: Video Playback Stutters, Feels Like Slow Internet
+
+**Symptoms:**
+- YouTube and other video playback stutters or stalls while games run fine
+- Feels like a network problem, but downloads and speed tests are fine
+- Audio over DisplayPort is silent, slow or desynced at the same time
+
+**Cause:** the [DisplayPort audio clock bug](audio.md). PipeWire drives its whole graph off the HDMI/DisplayPort sink's clock, so a sink that consumes samples at roughly 39.5 kHz while applications feed it 48 kHz stalls the shared media clock, and everything synced to audio stutters with it. On the tested board this presented as unexplained browser-video stutter on an otherwise healthy box, and fixing the audio clock fixed the "slow internet" at the same moment.
+
+**Check the audio clock before debugging the network or GPU:** the [audio page](audio.md) has the register check and the no-build fix.
+
+Tested by: @Weijtmans. BC-250, Bazzite (Fedora Atomic 43), kernel 6.17.7-ba29.
+
 ---
 
 ## System Configuration Issues


### PR DESCRIPTION
Discoverability follow-up to the audio page. The DisplayPort audio clock bug does not only break audio: PipeWire clocks its whole graph off the sink, so a sink draining at ~39.5 kHz stalls the shared media clock and video playback synced to audio stutters with it. In practice that presents as "YouTube stutters, the internet feels slow" on a box where games and downloads are fine, and someone starting from that symptom lands on the performance page, not the audio page.

- `troubleshooting/performance.md`: new entry under Stuttering and Frame Pacing with the symptom triple (browser video stutters, network is fine, DP audio silent/slow at the same time), the mechanism, and the pointer to the audio page's register check before any network or GPU debugging. First-party: this exact misdirection happened on the tested board.
- `troubleshooting/audio.md`: one sentence after the watcher's service-pitfall list, linking the maintained version of the watcher (`bc250-audio-dto-fix.sh` in [bc250-tools](https://github.com/Weijtmans/bc250-tools), with status/apply/revert/watch/install-service and both pitfalls handled). The inline snippet stays, the tool is for people who want the packaged form.

`mkdocs build --strict` passes.