### PR TITLE
docs: add flags for cpupower

### DIFF
--- a/docs/system/8core-unlock.md
+++ b/docs/system/8core-unlock.md
@@ -148,7 +148,7 @@ Back up any existing `.aml` files **outside** `/etc/initcpio/acpi_override/` fir
 Check it worked:
 
 ```bash
-cpupower idle-info
+cpupower --cpu all idle-info --silent
 # every CPU, including 12-15, should now report C-states
 ```
 


### PR DESCRIPTION
In the current invocation the `--cpu` and `--silent` flags are missing, which results in:

- a random CPU being picked for details
- a lot more data being listed than is really needed for verification

before:

```
$ cpupower idle-info
CPUidle driver: acpi_idle
CPUidle governor: menu
analyzing CPU 12:

Number of idle states: 4
Available idle states: POLL C1 C2 C3
POLL:
Flags/Description: CPUIDLE CORE POLL IDLE
Latency: 0
Residency: 0
Usage: 946
Duration: 56142
C1:
Flags/Description: ACPI FFH MWAIT 0x0
Latency: 1
Residency: 2
Usage: 149456
Duration: 48326097
C2:
Flags/Description: ACPI IOPORT 0x414
Latency: 350
Residency: 700
Usage: 4780
Duration: 4302472
C3:
Flags/Description: ACPI IOPORT 0x415
Latency: 400
Residency: 800
Usage: 64055
Duration: 1581475808
```

after

```
$ cpupower --cpu all idle-info --silent
CPUidle driver: acpi_idle
CPUidle governor: menu
analyzing CPU 0:

Number of idle states: 4
Available idle states: POLL C1 C2 C3

analyzing CPU 1:

Number of idle states: 4
Available idle states: POLL C1 C2 C3

analyzing CPU 2:

Number of idle states: 4
Available idle states: POLL C1 C2 C3

analyzing CPU 3:

Number of idle states: 4
Available idle states: POLL C1 C2 C3

analyzing CPU 4:

Number of idle states: 4
Available idle states: POLL C1 C2 C3

analyzing CPU 5:

Number of idle states: 4
Available idle states: POLL C1 C2 C3

analyzing CPU 6:

Number of idle states: 4
Available idle states: POLL C1 C2 C3

analyzing CPU 7:

Number of idle states: 4
Available idle states: POLL C1 C2 C3

analyzing CPU 8:

Number of idle states: 4
Available idle states: POLL C1 C2 C3

analyzing CPU 9:

Number of idle states: 4
Available idle states: POLL C1 C2 C3

analyzing CPU 10:

Number of idle states: 4
Available idle states: POLL C1 C2 C3

analyzing CPU 11:

Number of idle states: 4
Available idle states: POLL C1 C2 C3

analyzing CPU 12:

Number of idle states: 4
Available idle states: POLL C1 C2 C3

analyzing CPU 13:

Number of idle states: 4
Available idle states: POLL C1 C2 C3

analyzing CPU 14:

Number of idle states: 4
Available idle states: POLL C1 C2 C3

analyzing CPU 15:

Number of idle states: 4
Available idle states: POLL C1 C2 C3
```

could be condensed further like this:

```
$ cpupower --cpu all idle-info --silent | grep -i '\(analyzing\|available idle\)'
analyzing CPU 0:
Available idle states: POLL C1 C2 C3
analyzing CPU 1:
Available idle states: POLL C1 C2 C3
analyzing CPU 2:
Available idle states: POLL C1 C2 C3
analyzing CPU 3:
Available idle states: POLL C1 C2 C3
analyzing CPU 4:
Available idle states: POLL C1 C2 C3
analyzing CPU 5:
Available idle states: POLL C1 C2 C3
analyzing CPU 6:
Available idle states: POLL C1 C2 C3
analyzing CPU 7:
Available idle states: POLL C1 C2 C3
analyzing CPU 8:
Available idle states: POLL C1 C2 C3
analyzing CPU 9:
Available idle states: POLL C1 C2 C3
analyzing CPU 10:
Available idle states: POLL C1 C2 C3
analyzing CPU 11:
Available idle states: POLL C1 C2 C3
analyzing CPU 12:
Available idle states: POLL C1 C2 C3
analyzing CPU 13:
Available idle states: POLL C1 C2 C3
analyzing CPU 14:
Available idle states: POLL C1 C2 C3
analyzing CPU 15:
Available idle states: POLL C1 C2 C3
```

All 16 CPUs should report _four_ idle states (`POLL C1 C2 C3`).

OT: thank you for maintaining this repository! This is _the_ ressource for me to read up on any news on the BC-250. Keep up the great work! :+1: 